### PR TITLE
Add therapist manual reservations

### DIFF
--- a/src/components/therapist/TherapistDashboard.tsx
+++ b/src/components/therapist/TherapistDashboard.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Table, Spinner } from "react-bootstrap";
+import { useSession } from "next-auth/react";
+
+interface ReservationItem {
+  id: string;
+  date: string;
+  service: { name: string };
+  user: { name: string };
+}
+
+export default function TherapistDashboard() {
+  const { data: session } = useSession();
+  const [rows, setRows] = useState<ReservationItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!session?.user?.id) return;
+    fetch(`/api/therapist/${session.user.id}/reservations`)
+      .then((r) => r.json())
+      .then(setRows)
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, [session?.user?.id]);
+
+  const calLink = (r: ReservationItem) => {
+    const start = new Date(r.date);
+    const end = new Date(start.getTime() + 60 * 60 * 1000);
+    const fmt = (d: Date) => d.toISOString().replace(/[-:]|\.\d{3}/g, "");
+    return (
+      "https://www.google.com/calendar/render?action=TEMPLATE" +
+      `&text=${encodeURIComponent(r.service.name)}` +
+      `&dates=${fmt(start)}/${fmt(end)}` +
+      `&details=${encodeURIComponent(r.service.name)}`
+    );
+  };
+
+  if (loading) return <Spinner className="m-5" animation="border" />;
+
+  return (
+    <Table hover responsive className="dashboard-table">
+      <thead>
+        <tr>
+          <th>Fecha</th>
+          <th>Cliente</th>
+          <th>Servicio</th>
+          <th>Calendario</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r) => {
+          const dt = new Date(r.date);
+          const disp = `${dt.toLocaleDateString()} ${dt.toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+          })}`;
+          return (
+            <tr key={r.id}>
+              <td>{disp}</td>
+              <td>{r.user.name}</td>
+              <td>{r.service.name}</td>
+              <td>
+                <a href={calLink(r)} target="_blank" rel="noopener noreferrer">
+                  Añadir
+                </a>
+              </td>
+            </tr>
+          );
+        })}
+        {rows.length === 0 && (
+          <tr>
+            <td colSpan={4} className="text-center">
+              — Sin reservaciones —
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </Table>
+  );
+}

--- a/src/components/therapist/TherapistManualReservation.tsx
+++ b/src/components/therapist/TherapistManualReservation.tsx
@@ -1,0 +1,411 @@
+// src/components/therapist/TherapistManualReservation.tsx
+"use client";
+
+import React, { useState, useEffect } from "react";
+import {
+  Form,
+  Button,
+  Alert,
+  Modal,
+  Spinner,
+  Accordion,
+  Row,
+  Col,
+} from "react-bootstrap";
+
+interface Client {
+  id: string;
+  name: string;
+  email: string;
+}
+
+interface Package {
+  id: string;
+  name: string;
+  sessions: number;
+}
+
+interface Therapist {
+  id: string;
+  name: string;
+}
+
+type Slot = {
+  therapistId:    string;
+  date:           string;   // "YYYY-MM-DD"
+  time:           string;   // "HH:MM"
+  availableTimes: string[];
+  loading:        boolean;
+};
+
+type PaymentMethod = "efectivo" | "transferencia";
+
+export default function TherapistManualReservation() {
+  // —— Listas maestras ——
+  const [clients,    setClients]    = useState<Client[]>([]);
+  const [packages,   setPackages]   = useState<Package[]>([]);
+  const [therapists, setTherapists] = useState<Therapist[]>([]);
+
+  // —— Selección principal ——
+  const [clientId,  setClientId]  = useState<string>("");
+  const [packageId, setPackageId] = useState<string>("");
+
+  // —— Slots dinámicos según sesiones del paquete ——
+  const [slots, setSlots] = useState<Slot[]>([]);
+
+  // —— Mensajes UI ——
+  const [error,   setError]   = useState<string|null>(null);
+  const [success, setSuccess] = useState<string|null>(null);
+
+  // —— Wizard de pago ——
+  const [showPayment,   setShowPayment]   = useState<boolean>(false);
+  const [paymentMethod, setPaymentMethod] = useState<PaymentMethod>("efectivo");
+
+  // —— Helper fetch con cookies ——
+  const fetchJSON = (url: string, opts: RequestInit = {}) =>
+    fetch(url, {
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      ...opts,
+    });
+
+  // —— 1) Carga inicial de datos ——
+useEffect(() => {
+    fetchJSON("/api/admin/clients")
+      .then((r) => (r.ok ? r.json() : []))
+      .then(setClients)
+      .catch(() => setError("Error cargando clientes"));
+
+    fetchJSON("/api/admin/packages")
+      .then((r) => (r.ok ? r.json() : []))
+      .then(setPackages)
+      .catch(() => setError("Error cargando paquetes"));
+
+    fetchJSON("/api/admin/therapists")
+      .then((r) => (r.ok ? r.json() : []))
+      .then((list: Therapist[]) => setTherapists(list))
+      .catch(() => setError("Error cargando terapeutas"));
+  }, []);
+
+  // —— 2) Cuando cambia paquete, regenerar X slots ——
+  useEffect(() => {
+    if (!packageId) {
+      setSlots([]);
+      return;
+    }
+    const pkg = packages.find((p) => p.id === packageId);
+    const count = pkg?.sessions ?? 1;
+    const defaultTher = therapists.length === 1 ? therapists[0].id : "";
+    setSlots(
+      Array.from({ length: count }, () => ({
+        therapistId: defaultTher,
+        date: "",
+        time: "",
+        availableTimes: [],
+        loading: false,
+      }))
+    );
+  }, [packageId, packages, therapists]);
+
+  // —— 3) “Hoy” en local para filtrar horas pasadas ——
+  const todayLocal = React.useMemo(() => {
+    const d = new Date();
+    const yyyy = d.getFullYear();
+    const mm   = String(d.getMonth() + 1).padStart(2, "0");
+    const dd   = String(d.getDate()).padStart(2, "0");
+    return `${yyyy}-${mm}-${dd}`; // "YYYY-MM-DD"
+  }, []);
+
+  // —— 4) Cargar disponibilidad para un slot concreto ——
+  const loadTimes = async (idx: number) => {
+    const s = slots[idx];
+    if (!s.therapistId || !s.date) return;
+
+    const copy = [...slots];
+    copy[idx].loading = true;
+    copy[idx].availableTimes = [];
+    setSlots(copy);
+
+    try {
+      const res = await fetchJSON(
+        `/api/admin/therapists/${s.therapistId}/availability?date=${s.date}`
+      );
+      if (!res.ok) throw new Error("No hay horarios");
+
+      let times: string[] = await res.json();
+
+      // filtrar horas pasadas si la fecha es hoyLocal
+      if (s.date === todayLocal) {
+        const nowH = new Date().getHours();
+        times = times.filter(t => {
+          const h = parseInt(t.slice(0, 2), 10);
+          return h > nowH;
+        });
+      }
+
+      copy[idx].loading = false;
+      copy[idx].availableTimes = times;
+      copy[idx].time = times[0] ?? "";
+      setSlots(copy);
+    } catch (e: any) {
+      copy[idx].loading = false;
+      setSlots(copy);
+      setError(e.message);
+    }
+  };
+
+  // —— 5) Handlers de cambio ——
+  const onTherapistChange = (i: number, id: string) => {
+    if (therapists.length === 1) return;
+    const c = [...slots];
+    c[i] = { therapistId: id, date: "", time: "", availableTimes: [], loading: false };
+    setSlots(c);
+  };
+
+  const onDateChange = (i: number, date: string) => {
+    const c = [...slots];
+    c[i].date = date;
+    c[i].time = "";
+    c[i].availableTimes = [];
+    setSlots(c);
+    loadTimes(i);
+  };
+
+  const onTimeChange = (i: number, time: string) => {
+    const c = [...slots];
+    c[i].time = time;
+    setSlots(c);
+  };
+
+  // —— 6) Validar y abrir wizard de pago ——
+  const handleProceedToPay = () => {
+    setError(null);
+    setSuccess(null);
+    if (!clientId || !packageId || slots.some(s => !s.therapistId || !s.date || !s.time)) {
+      setError("Completa todos los campos de cada sesión antes de pagar.");
+      return;
+    }
+    setShowPayment(true);
+  };
+
+  // —— 7) Confirmar pago: crear reservas + pago ——
+  const handleConfirmPayment = async () => {
+    setError(null);
+
+    try {
+      // 7.1 POST único con todas las sesiones
+      const createRes = await fetchJSON("/api/admin/reservations", {
+        method: "POST",
+        body: JSON.stringify({
+          clientId,
+          packageId,
+          sessions: slots.map(s => ({
+            therapistId: s.therapistId,
+            date: new Date(`${s.date}T${s.time}:00`).toISOString(),
+          })),
+        }),
+      });
+
+      if (createRes.status === 400) {
+        const { message } = await createRes.json();
+        throw new Error(message);
+      }
+      if (!createRes.ok) {
+        throw new Error("Error creando la reservación");
+      }
+
+      const { id: reservationId } = await createRes.json();
+
+      // 7.2 POST al endpoint de pago con reservationId
+      const payRes = await fetchJSON(
+        `/api/admin/reservations/${reservationId}/payment`,
+        {
+          method: "POST",
+          body: JSON.stringify({ method: paymentMethod }),
+        }
+      );
+      if (!payRes.ok) {
+        throw new Error("Error registrando el pago");
+      }
+
+      // 7.3 Reset + éxito
+      setShowPayment(false);
+      setSuccess("Reservación creada y pago registrado correctamente.");
+      setClientId("");
+      setPackageId("");
+      setSlots([]);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <>
+      <h2>Generar reservación manual</h2>
+      {error   && <Alert variant="danger">{error}</Alert>}
+      {success && <Alert variant="success">{success}</Alert>}
+
+      <Form>
+        {/* Selección de cliente */}
+        <Form.Group className="mb-3">
+          <Form.Label>Cliente</Form.Label>
+          <Form.Select value={clientId} onChange={e => setClientId(e.target.value)}>
+            <option value="">-- Selecciona cliente --</option>
+            {clients.map(c => (
+              <option key={c.id} value={c.id}>
+                {c.name} ({c.email})
+              </option>
+            ))}
+          </Form.Select>
+        </Form.Group>
+
+        {/* Selección de paquete */}
+        <Form.Group className="mb-3">
+          <Form.Label>Paquete</Form.Label>
+          <Form.Select value={packageId} onChange={e => setPackageId(e.target.value)}>
+            <option value="">-- Selecciona paquete --</option>
+            {packages.map(p => (
+              <option key={p.id} value={p.id}>
+                {p.name} ({p.sessions} sesión{p.sessions > 1 ? "es" : ""})
+              </option>
+            ))}
+          </Form.Select>
+        </Form.Group>
+
+        {/* Slots dinámicos */}
+        {slots.map((s, i) => (
+          <Accordion key={i} className="mb-2" defaultActiveKey="0">
+            <Accordion.Item eventKey={String(i)}>
+              <Accordion.Header>Sesión {i + 1}</Accordion.Header>
+              <Accordion.Body>
+                <Row>
+                  <Col md={6}>
+                    <Form.Group className="mb-2">
+                      <Form.Label>Terapeuta</Form.Label>
+                      {therapists.length === 1 ? (
+                        <Form.Control
+                          type="text"
+                          readOnly
+                          plaintext
+                          defaultValue={therapists[0].name}
+                        />
+                      ) : (
+                        <Form.Select
+                          value={s.therapistId}
+                          onChange={e => onTherapistChange(i, e.target.value)}
+                        >
+                          <option value="">-- Selecciona terapeuta --</option>
+                          {therapists.map(t => (
+                            <option key={t.id} value={t.id}>
+                              {t.name}
+                            </option>
+                          ))}
+                        </Form.Select>
+                      )}
+                    </Form.Group>
+                  </Col>
+                  <Col md={6}>
+                    <Form.Group className="mb-2">
+                      <Form.Label>Fecha</Form.Label>
+                      <Form.Control
+                        type="date"
+                        value={s.date}
+                        disabled={!s.therapistId}
+                        onChange={e => onDateChange(i, e.target.value)}
+                      />
+                    </Form.Group>
+                  </Col>
+                </Row>
+
+                <Form.Group>
+                  <Form.Label>Hora</Form.Label>
+                  {s.loading ? (
+                    <Spinner animation="border" size="sm" />
+                  ) : s.availableTimes.length > 0 ? (
+                    <Form.Select
+                      value={s.time}
+                      onChange={e => onTimeChange(i, e.target.value)}
+                    >
+                      <option value="">-- Selecciona hora --</option>
+                      {s.availableTimes.map(t => (
+                        <option key={t} value={t}>
+                          {t}
+                        </option>
+                      ))}
+                    </Form.Select>
+                  ) : (
+                    <Alert variant="info" className="py-1">
+                      {s.date && s.therapistId
+                        ? "No hay horarios libres"
+                        : "Selecciona terapeuta y fecha primero"}
+                    </Alert>
+                  )}
+                  <Button
+                    variant="link"
+                    size="sm"
+                    disabled={!s.therapistId || !s.date}
+                    onClick={() => loadTimes(i)}
+                  >
+                    Refrescar horarios
+                  </Button>
+                </Form.Group>
+              </Accordion.Body>
+            </Accordion.Item>
+          </Accordion>
+        ))}
+
+        <Button
+          className="mt-3"
+          onClick={handleProceedToPay}
+          disabled={
+            !clientId ||
+            !packageId ||
+            slots.some(s => !s.therapistId || !s.date || !s.time)
+          }
+        >
+          Pasar a pagar
+        </Button>
+      </Form>
+
+      {/* ——— Modal de pago ——— */}
+      <Modal show={showPayment} onHide={() => setShowPayment(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Confirmar pago</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <h5>Resumen de reservaciones</h5>
+          <ul>
+            {slots.map((s, i) => (
+              <li key={i}>
+                Sesión {i + 1}: {s.date} a las {s.time} con{" "}
+                {therapists.find(t => t.id === s.therapistId)?.name}
+              </li>
+            ))}
+          </ul>
+          <Form>
+            <Form.Check
+              type="radio"
+              label="Efectivo"
+              name="pay"
+              checked={paymentMethod === "efectivo"}
+              onChange={() => setPaymentMethod("efectivo")}
+            />
+            <Form.Check
+              type="radio"
+              label="Transferencia"
+              name="pay"
+              checked={paymentMethod === "transferencia"}
+              onChange={() => setPaymentMethod("transferencia")}
+            />
+          </Form>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={() => setShowPayment(false)}>
+            Cancelar
+          </Button>
+          <Button onClick={handleConfirmPayment}>Confirmar pago</Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}

--- a/src/pages/api/admin/clients/index.ts
+++ b/src/pages/api/admin/clients/index.ts
@@ -6,10 +6,19 @@ import bcrypt from "bcrypt";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
-  if (!session?.user?.id) return res.status(401).json({ error: "Unauthorized" });
+  if (!session?.user?.id) {
+    await prisma.$disconnect();
+    return res.status(401).json({ error: "Unauthorized" });
+  }
 
   const user = await prisma.user.findUnique({ where: { id: session.user.id } });
-  if (user?.role !== "ADMIN") return res.status(403).json({ error: "Forbidden" });
+  const role = user?.role;
+  const isAdmin = role === "ADMIN";
+  const isTherapist = role === "THERAPIST";
+  if (!isAdmin && !isTherapist) {
+    await prisma.$disconnect();
+    return res.status(403).json({ error: "Forbidden" });
+  }
 
   if (req.method === "GET") {
     const { search = "" } = req.query as { search?: string };
@@ -23,10 +32,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       },
       select: { id: true, name: true, email: true, phone: true, role: true },
     });
-    return res.status(200).json(clients);
+    const ok = res.status(200).json(clients);
+    await prisma.$disconnect();
+    return ok;
   }
 
   if (req.method === "POST") {
+    if (!isAdmin) {
+      await prisma.$disconnect();
+      return res.status(403).json({ error: "Forbidden" });
+    }
     const { name, email, phone, password } = req.body as {
       name: string;
       email: string;
@@ -37,9 +52,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const client = await prisma.user.create({
       data: { name, email, phone, password: hashed, role: "CLIENTE" },
     });
-    return res.status(200).json(client);
+    const ok = res.status(200).json(client);
+    await prisma.$disconnect();
+    return ok;
   }
 
   res.setHeader("Allow", ["GET", "POST"]);
-  res.status(405).end();
+  const na = res.status(405).end();
+  await prisma.$disconnect();
+  return na;
 }

--- a/src/pages/api/admin/packages.ts
+++ b/src/pages/api/admin/packages.ts
@@ -7,9 +7,18 @@ import prisma                       from "@/lib/prisma";
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   // 1) verificación de sesión y rol ADMIN:
   const session = await getServerSession(req, res, authOptions);
-  if (!session?.user?.id) return res.status(401).json({ error: "Unauthorized" });
-  const admin = await prisma.user.findUnique({ where: { id: session.user.id } });
-  if (admin?.role !== "ADMIN") return res.status(403).json({ error: "Forbidden" });
+  if (!session?.user?.id) {
+    await prisma.$disconnect();
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+  const user = await prisma.user.findUnique({ where: { id: session.user.id } });
+  const role = user?.role;
+  const isAdmin = role === "ADMIN";
+  const isTherapist = role === "THERAPIST";
+  if (!isAdmin && !isTherapist) {
+    await prisma.$disconnect();
+    return res.status(403).json({ error: "Forbidden" });
+  }
 
   if (req.method === "GET") {
     // 2) devolvemos todos los paquetes con id, name y sessions
@@ -21,9 +30,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         sessions: true,
       },
     });
-    return res.status(200).json(list);
+    const ok = res.status(200).json(list);
+    await prisma.$disconnect();
+    return ok;
   }
 
   res.setHeader("Allow", ["GET"]);
-  return res.status(405).end("Method Not Allowed");
+  const na = res.status(405).end("Method Not Allowed");
+  await prisma.$disconnect();
+  return na;
 }

--- a/src/pages/api/admin/services.ts
+++ b/src/pages/api/admin/services.ts
@@ -5,15 +5,25 @@ import prisma from "@/lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
-  if (!session?.user?.id) return res.status(401).json({ error: "Unauthorized" });
+  if (!session?.user?.id) {
+    await prisma.$disconnect();
+    return res.status(401).json({ error: "Unauthorized" });
+  }
   const admin = await prisma.user.findUnique({ where: { id: session.user.id } });
-  if (admin?.role !== "ADMIN") return res.status(403).json({ error: "Forbidden" });
+  if (admin?.role !== "ADMIN") {
+    await prisma.$disconnect();
+    return res.status(403).json({ error: "Forbidden" });
+  }
 
   if (req.method === "GET") {
     const list = await prisma.service.findMany({ orderBy: { name: "asc" } });
-    return res.status(200).json(list);
+    const ok = res.status(200).json(list);
+    await prisma.$disconnect();
+    return ok;
   }
 
   res.setHeader("Allow", ["GET"]);
-  res.status(405).end();
+  const na = res.status(405).end();
+  await prisma.$disconnect();
+  return na;
 }

--- a/src/pages/api/admin/therapists/[therapistId].ts
+++ b/src/pages/api/admin/therapists/[therapistId].ts
@@ -5,9 +5,15 @@ import prisma from "@/lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
-  if (!session?.user?.id) return res.status(401).json({ error: "Unauthorized" });
+  if (!session?.user?.id) {
+    await prisma.$disconnect();
+    return res.status(401).json({ error: "Unauthorized" });
+  }
   const user = await prisma.user.findUnique({ where: { id: session.user.id } });
-  if (user?.role !== "ADMIN") return res.status(403).json({ error: "Forbidden" });
+  if (user?.role !== "ADMIN") {
+    await prisma.$disconnect();
+    return res.status(403).json({ error: "Forbidden" });
+  }
 
   const { therapistId } = req.query as { therapistId: string };
 
@@ -21,14 +27,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       where: { id: therapistId },
       data: { name, specialty, isActive },
     });
-    return res.status(200).json(ther);
+    const ok = res.status(200).json(ther);
+    await prisma.$disconnect();
+    return ok;
   }
 
   if (req.method === "DELETE") {
     await prisma.therapist.delete({ where: { id: therapistId } });
-    return res.status(200).json({ ok: true });
+    const ok = res.status(200).json({ ok: true });
+    await prisma.$disconnect();
+    return ok;
   }
 
   res.setHeader("Allow", ["PUT", "DELETE"]);
-  res.status(405).end();
+  const na = res.status(405).end();
+  await prisma.$disconnect();
+  return na;
 }

--- a/src/pages/api/admin/therapists/index.ts
+++ b/src/pages/api/admin/therapists/index.ts
@@ -5,27 +5,47 @@ import prisma from "@/lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
-  if (!session?.user?.id) return res.status(401).json({ error: "Unauthorized" });
+  if (!session?.user?.id) {
+    await prisma.$disconnect();
+    return res.status(401).json({ error: "Unauthorized" });
+  }
   const user = await prisma.user.findUnique({ where: { id: session.user.id } });
-  if (user?.role !== "ADMIN") return res.status(403).json({ error: "Forbidden" });
+  const role = user?.role;
+  const isAdmin = role === "ADMIN";
+  const isTherapist = role === "THERAPIST";
+  if (!isAdmin && !isTherapist) {
+    await prisma.$disconnect();
+    return res.status(403).json({ error: "Forbidden" });
+  }
 
   if (req.method === "GET") {
     const { search = "" } = req.query as { search?: string };
+    const where = isTherapist
+      ? { id: session.user.id }
+      : { name: { contains: search, mode: "insensitive" } };
     const list = await prisma.therapist.findMany({
-      where: {
-        name: { contains: search, mode: "insensitive" },
-      },
+      where,
       orderBy: { name: "asc" },
     });
-    return res.status(200).json(list);
+    const ok = res.status(200).json(list);
+    await prisma.$disconnect();
+    return ok;
   }
 
   if (req.method === "POST") {
+    if (!isAdmin) {
+      await prisma.$disconnect();
+      return res.status(403).json({ error: "Forbidden" });
+    }
     const { name, specialty } = req.body as { name: string; specialty?: string };
     const ther = await prisma.therapist.create({ data: { name, specialty } });
-    return res.status(200).json(ther);
+    const ok = res.status(200).json(ther);
+    await prisma.$disconnect();
+    return ok;
   }
 
   res.setHeader("Allow", ["GET", "POST"]);
-  res.status(405).end();
+  const na = res.status(405).end();
+  await prisma.$disconnect();
+  return na;
 }

--- a/src/pages/api/appointments/history.ts
+++ b/src/pages/api/appointments/history.ts
@@ -16,11 +16,14 @@ export default async function handler(
 ) {
   if (req.method !== "GET") {
     res.setHeader("Allow", "GET");
-    return res.status(405).json({ error: "Method not allowed" });
+    const na = res.status(405).json({ error: "Method not allowed" });
+    await prisma.$disconnect();
+    return na;
   }
 
   const session = await getSession({ req });
   if (!session?.user?.id) {
+    await prisma.$disconnect();
     return res.status(401).json({ error: "Unauthorized" });
   }
 
@@ -37,5 +40,7 @@ export default async function handler(
     therapistName: r.therapist.name,
   }));
 
-  res.status(200).json(data);
+  const ok = res.status(200).json(data);
+  await prisma.$disconnect();
+  return ok;
 }

--- a/src/pages/api/appointments/index.ts
+++ b/src/pages/api/appointments/index.ts
@@ -6,6 +6,7 @@ import prisma from "@/lib/prisma";
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
   if (!session?.user?.id) {
+    await prisma.$disconnect();
     return res.status(401).json({ error: "Unauthorized" });
   }
 
@@ -23,9 +24,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       therapistName: r.therapist.name,    // ✅ Correcto
     }));
 
-    return res.status(200).json({ reservations: mapped });
+    const ok = res.status(200).json({ reservations: mapped });
+    await prisma.$disconnect();
+    return ok;
   }
 
   res.setHeader("Allow", ["GET"]);
-  return res.status(405).end(`Method ${req.method} Not Allowed`);
+  const na = res.status(405).end(`Method ${req.method} Not Allowed`);
+  await prisma.$disconnect();
+  return na;
 }

--- a/src/pages/api/appointments/slots.ts
+++ b/src/pages/api/appointments/slots.ts
@@ -18,5 +18,7 @@ export default async function handler(
     },
   });
   const hours = taken.map((r) => new Date(r.date).getHours());
-  res.json(hours);
+  const ok = res.json(hours);
+  await prisma.$disconnect();
+  return ok;
 }

--- a/src/pages/api/therapist/[id]/reservations.ts
+++ b/src/pages/api/therapist/[id]/reservations.ts
@@ -6,7 +6,9 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const { id } = req.query;
   if (req.method !== "GET") {
     res.setHeader("Allow", ["GET"]);
-    return res.status(405).end(`Method ${req.method} Not Allowed`);
+    const na = res.status(405).end(`Method ${req.method} Not Allowed`);
+    await prisma.$disconnect();
+    return na;
   }
 
   const reservations = await prisma.reservation.findMany({
@@ -14,5 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     include: { service: true, user: true },
     orderBy: { date: "asc" },
   });
-  return res.status(200).json(reservations);
+  const ok = res.status(200).json(reservations);
+  await prisma.$disconnect();
+  return ok;
 }

--- a/src/pages/api/user/packages.ts
+++ b/src/pages/api/user/packages.ts
@@ -9,11 +9,14 @@ export default async function handler(
   res: NextApiResponse
 ) {
   if (req.method !== "GET") {
-    return res.status(405).json({ error: "Método no permitido" });
+    const na = res.status(405).json({ error: "Método no permitido" });
+    await prisma.$disconnect();
+    return na;
   }
 
   const session = await getServerSession(req, res, authOptions);
   if (!session?.user?.id) {
+    await prisma.$disconnect();
     return res.status(401).json({ error: "No autorizado" });
   }
 
@@ -31,5 +34,7 @@ export default async function handler(
     inscription: up.pkg.inscription,
   }));
 
-  return res.status(200).json({ packages });
+  const ok = res.status(200).json({ packages });
+  await prisma.$disconnect();
+  return ok;
 }

--- a/src/pages/therapist/index.tsx
+++ b/src/pages/therapist/index.tsx
@@ -1,0 +1,34 @@
+import { GetServerSideProps } from "next";
+import Head from "next/head";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../api/auth/[...nextauth]";
+import TherapistDashboard from "@/components/therapist/TherapistDashboard";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+
+export default function TherapistPage() {
+  return (
+    <>
+      <Head>
+        <title>Dashboard Terapeuta • Bloom Fisio</title>
+      </Head>
+      <Navbar />
+      <div className="py-4 container">
+        <h2 className="mb-4 text-center">Mis Reservaciones</h2>
+        <TherapistDashboard />
+      </div>
+      <Footer />
+    </>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const session = await getServerSession(ctx.req, ctx.res, authOptions);
+  if (!session) {
+    return { redirect: { destination: "/login", permanent: false } };
+  }
+  if ((session.user as any).role !== "THERAPIST") {
+    return { redirect: { destination: "/", permanent: false } };
+  }
+  return { props: {} };
+};

--- a/src/pages/therapist/manual.tsx
+++ b/src/pages/therapist/manual.tsx
@@ -1,0 +1,33 @@
+import { GetServerSideProps } from "next";
+import Head from "next/head";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../api/auth/[...nextauth]";
+import TherapistManualReservation from "@/components/therapist/TherapistManualReservation";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+
+export default function TherapistManualPage() {
+  return (
+    <>
+      <Head>
+        <title>Reservación Manual • Bloom Fisio</title>
+      </Head>
+      <Navbar />
+      <div className="py-4 container">
+        <TherapistManualReservation />
+      </div>
+      <Footer />
+    </>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const session = await getServerSession(ctx.req, ctx.res, authOptions);
+  if (!session) {
+    return { redirect: { destination: "/login", permanent: false } };
+  }
+  if ((session.user as any).role !== "THERAPIST") {
+    return { redirect: { destination: "/", permanent: false } };
+  }
+  return { props: {} };
+};


### PR DESCRIPTION
## Summary
- allow therapist role to access certain admin API routes
- restrict writes to admins only
- permit therapists to create manual reservations for themselves
- add TherapistManualReservation component and page
- add therapist dashboard listing reservations
- **fix**: therapists now see only themselves when booking manual reservations

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685367503b4c8332aa6ddfd673a95d71