### PR TITLE
Fix reservation history data selects

### DIFF
--- a/src/components/dashboard/HistorySection.tsx
+++ b/src/components/dashboard/HistorySection.tsx
@@ -18,8 +18,8 @@ import { FaEdit, FaTrash, FaCalendarPlus } from "react-icons/fa";
 interface HistoryItem {
   id: string;
   date: string;        // ISO string
-  serviceName: string; // viene de tu API (/api/appointments/history)
-  therapistName: string;
+  serviceName: string | null; // viene de tu API (/api/appointments/history)
+  therapistName: string | null;
 }
 
 export default function HistorySection() {
@@ -81,10 +81,10 @@ export default function HistorySection() {
     const fmt = (x: Date) => x.toISOString().replace(/[-:]|\.\d{3}/g, "");
     return (
       "https://www.google.com/calendar/render?action=TEMPLATE" +
-      `&text=${encodeURIComponent(item.serviceName)}` +
+      `&text=${encodeURIComponent(item.serviceName ?? "Reserva")}` +
       `&dates=${fmt(start)}/${fmt(end)}` +
-      `&details=${encodeURIComponent(item.serviceName)}` +
-      `&location=${encodeURIComponent(item.serviceName)}`
+      `&details=${encodeURIComponent(item.serviceName ?? "")}` +
+      `&location=${encodeURIComponent(item.serviceName ?? "")}`
     );
   };
 
@@ -119,8 +119,8 @@ export default function HistorySection() {
               )}`;
               return (
                 <tr key={r.id}>
-                  <td>{r.serviceName}</td>
-                  <td>{r.therapistName}</td>
+                  <td>{r.serviceName ?? "—"}</td>
+                  <td>{r.therapistName ?? "—"}</td>
                   <td>{display}</td>
                   <td>
                     <OverlayTrigger

--- a/src/pages/api/admin/reservations.ts
+++ b/src/pages/api/admin/reservations.ts
@@ -10,8 +10,8 @@ export interface Reservation {
   id: string;
   date: string;
   userName: string;
-  serviceName: string;
-  therapistName: string;
+  serviceName: string | null;
+  therapistName: string | null;
   paymentMethod: string;
   sessionNumber: number;
   totalSessions: number;
@@ -38,7 +38,9 @@ export default async function handler(
   }
 
   const { start, end, date } = req.query as {
-    start?: string; end?: string; date?: string;
+    start?: string;
+    end?: string;
+    date?: string;
   };
 
   // GET rango completo (calendario)
@@ -50,7 +52,11 @@ export default async function handler(
         date: { gte: from, lte: to },
         NOT:  { userPackageId: null },
       },
-      include: {
+      select: {
+        id:            true,
+        date:          true,
+        paymentMethod: true,
+        userPackageId: true,
         user:       { select: { name: true } },
         service:    { select: { name: true } },
         therapist:  { include: { user: { select: { name: true } } } },
@@ -76,8 +82,8 @@ export default async function handler(
           id:            r.id,
           date:          r.date.toISOString(),
           userName:      r.user.name ?? "—",
-          serviceName:   r.service.name,
-          therapistName: r.therapist.user.name ?? "—",  // <-- aquí también
+          serviceName:   r.service?.name ?? null,
+          therapistName: r.therapist?.user?.name ?? null,
           paymentMethod: r.paymentMethod,
           sessionNumber: idx + 1,
           totalSessions: total,
@@ -146,8 +152,8 @@ export default async function handler(
         id:            r.id,
         date:          r.date.toISOString(),
         userName:      me.name  ?? "—",
-        serviceName:   "", // el front re-fetchea para mostrar todo
-        therapistName: "", 
+        serviceName:   null,
+        therapistName: null,
         paymentMethod: r.paymentMethod,
         sessionNumber: 0,
         totalSessions: 0,

--- a/src/pages/api/appointments/history.ts
+++ b/src/pages/api/appointments/history.ts
@@ -7,8 +7,9 @@ import prisma                                 from "@/lib/prisma";
 export interface HistoryItem {
   id: string;
   date: string;
-  serviceName: string;
-  therapistName: string;
+  serviceName: string | null;
+  therapistName: string | null;
+  userPackageId: string | null;
 }
 
 export default async function handler(
@@ -29,7 +30,10 @@ export default async function handler(
 
   const reservations = await prisma.reservation.findMany({
     where: { userId: session.user.id },
-    include: {
+    select: {
+      id:            true,
+      date:          true,
+      userPackageId: true,
       service:   { select: { name: true } },
       therapist: { include: { user: { select: { name: true } } } },
     },
@@ -39,8 +43,9 @@ export default async function handler(
   const data: HistoryItem[] = reservations.map((r) => ({
     id:            r.id,
     date:          r.date.toISOString(),
-    serviceName:   r.service.name,
-    therapistName: r.therapist.user.name ?? "—",   // <-- aquí aseguramos string
+    serviceName:   r.service?.name ?? null,
+    therapistName: r.therapist?.user?.name ?? null,
+    userPackageId: r.userPackageId,
   }));
 
   await prisma.$disconnect();


### PR DESCRIPTION
## Summary
- fix includes/selects in appointment history API
- adjust admin reservations data selection and make names nullable
- allow nullable values in dashboard HistorySection component

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_68546ffa0b348332ba289063f222d562